### PR TITLE
Add function to initialize the client from an externalized config

### DIFF
--- a/internal/pkg/api/client.go
+++ b/internal/pkg/api/client.go
@@ -17,6 +17,10 @@ type Client struct {
 	restClient *restclientgo.RestClient
 }
 
+// New creates a new LangFuse client with the default endpoint and credentials from the environment.
+// It reads the LANGFUSE_HOST, LANGFUSE_PUBLIC_KEY, and LANGFUSE_SECRET_KEY environment variables
+// to configure the client. If the LANGFUSE_HOST environment variable is not set, it falls back to
+// a default endpoint.
 func New() *Client {
 	langfuseHost := os.Getenv("LANGFUSE_HOST")
 	if langfuseHost == "" {
@@ -26,9 +30,24 @@ func New() *Client {
 	publicKey := os.Getenv("LANGFUSE_PUBLIC_KEY")
 	secretKey := os.Getenv("LANGFUSE_SECRET_KEY")
 
-	restClient := restclientgo.New(langfuseHost)
+	return NewFromConfig(Config{
+		Host:      langfuseHost,
+		PublicKey: publicKey,
+		SecretKey: secretKey,
+	})
+}
+
+type Config struct {
+	Host      string
+	PublicKey string
+	SecretKey string
+}
+
+// NewFromConfig creates a new LangFuse client with the given configuration.
+func NewFromConfig(cfg Config) *Client {
+	restClient := restclientgo.New(cfg.Host)
 	restClient.SetRequestModifier(func(req *http.Request) *http.Request {
-		req.Header.Set("Authorization", basicAuth(publicKey, secretKey))
+		req.Header.Set("Authorization", basicAuth(cfg.PublicKey, cfg.SecretKey))
 		return req
 	})
 


### PR DESCRIPTION
This provides an alternative to initializing strictly from environment variables.